### PR TITLE
Upgrade to Spring Boot v2.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>spring-boot-starter-parent</artifactId>
     <groupId>org.springframework.boot</groupId>
-    <version>2.2.7.RELEASE</version>
+    <version>2.5.2</version>
   </parent>
 
   <properties>
@@ -185,6 +185,17 @@
       <artifactId>junit</artifactId>
       <groupId>junit</groupId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
       maximumPoolSize: 50
 
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQL94Dialect
+    database-platform: org.hibernate.dialect.PostgreSQL10Dialect
     hibernate:
       ddl-auto: update
     properties:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,6 @@ spring:
     username: postgres
     password: postgres
     driverClassName: org.postgresql.Driver
-    initialization-mode: always
     hikari:
       maximumPoolSize: 50
 
@@ -26,6 +25,10 @@ spring:
         jdbc:
           lob:
             non_contextual_creation: true
+
+  sql:
+    init:
+      mode: always
 
   rabbitmq:
     username: guest

--- a/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpointIT.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ssdc.exceptionmanager.model.dto.SkippedMessage;
 import uk.gov.ons.ssdc.exceptionmanager.model.entity.QuarantinedMessage;
 import uk.gov.ons.ssdc.exceptionmanager.model.repository.QuarantinedMessageRepository;
@@ -40,6 +41,7 @@ public class AdminEndpointIT {
   @Autowired private CachingDataStore cachingDataStore;
 
   @Before
+  @Transactional
   public void setUp() {
     quarantinedMessageRepository.deleteAllInBatch();
     rabbitQueueHelper.purgeQueue(TEST_QUEUE_NAME);


### PR DESCRIPTION
# Motivation and Context
We were running on a version of Spring Boot from May 2020.

# What has changed
Upgraded to the latest and greatest Spring Boot.

# How to test?
Run the ATs. Should be zero regression.

# Links
Trello: https://trello.com/c/8MZx3DE9