### PR TITLE
Record user who quarantined message for audit trail

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpoint.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.ons.ssdc.exceptionmanager.model.dto.AutoQuarantineRule;
 import uk.gov.ons.ssdc.exceptionmanager.model.dto.BadMessageReport;
 import uk.gov.ons.ssdc.exceptionmanager.model.dto.BadMessageSummary;
+import uk.gov.ons.ssdc.exceptionmanager.model.dto.SkipMessageRequest;
 import uk.gov.ons.ssdc.exceptionmanager.model.dto.SkippedMessage;
 import uk.gov.ons.ssdc.exceptionmanager.model.repository.QuarantinedMessageRepository;
 import uk.gov.ons.ssdc.exceptionmanager.persistence.CachingDataStore;
@@ -100,9 +101,10 @@ public class AdminEndpoint {
         .body(cachingDataStore.getBadMessageReports(messageHash));
   }
 
-  @GetMapping(path = "/skipmessage/{messageHash}")
-  public void skipMessage(@PathVariable("messageHash") String messageHash) {
-    cachingDataStore.skipMessage(messageHash);
+  @PostMapping(path = "/skipmessage")
+  public void skipMessage(@RequestBody SkipMessageRequest skipMessageRequest) {
+    cachingDataStore.skipMessage(
+        skipMessageRequest.getMessageHash(), skipMessageRequest.getSkippingUser());
   }
 
   @GetMapping(path = "/peekmessage/{messageHash}")

--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/ReportingEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/ReportingEndpoint.java
@@ -76,6 +76,9 @@ public class ReportingEndpoint {
         JsonHelper.convertObjectToJson(
             cachingDataStore.getBadMessageReports(skippedMessage.getMessageHash()));
 
+    String originatingUserOfSkipRequest =
+        cachingDataStore.getOriginatingUserOfSkipRequest(skippedMessage.getMessageHash());
+
     QuarantinedMessage quarantinedMessage = new QuarantinedMessage();
     quarantinedMessage.setId(UUID.randomUUID());
     quarantinedMessage.setContentType(skippedMessage.getContentType());
@@ -86,6 +89,7 @@ public class ReportingEndpoint {
     quarantinedMessage.setRoutingKey(skippedMessage.getRoutingKey());
     quarantinedMessage.setService(skippedMessage.getService());
     quarantinedMessage.setErrorReports(errorReports);
+    quarantinedMessage.setSkippingUser(originatingUserOfSkipRequest);
 
     quarantinedMessageRepository.save(quarantinedMessage);
   }

--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/dto/SkipMessageRequest.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/dto/SkipMessageRequest.java
@@ -1,0 +1,9 @@
+package uk.gov.ons.ssdc.exceptionmanager.model.dto;
+
+import lombok.Data;
+
+@Data
+public class SkipMessageRequest {
+  private String messageHash;
+  private String skippingUser;
+}

--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/entity/QuarantinedMessage.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/entity/QuarantinedMessage.java
@@ -40,6 +40,8 @@ public class QuarantinedMessage {
 
   @Column private String contentType;
 
+  @Column private String skippingUser;
+
   @Type(type = "jsonb")
   @Column(columnDefinition = "jsonb")
   private Map<String, JsonNode> headers;

--- a/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpointTest.java
@@ -22,6 +22,7 @@ import uk.gov.ons.ssdc.exceptionmanager.model.dto.BadMessageReport;
 import uk.gov.ons.ssdc.exceptionmanager.model.dto.BadMessageSummary;
 import uk.gov.ons.ssdc.exceptionmanager.model.dto.ExceptionReport;
 import uk.gov.ons.ssdc.exceptionmanager.model.dto.ExceptionStats;
+import uk.gov.ons.ssdc.exceptionmanager.model.dto.SkipMessageRequest;
 import uk.gov.ons.ssdc.exceptionmanager.model.dto.SkippedMessage;
 import uk.gov.ons.ssdc.exceptionmanager.persistence.CachingDataStore;
 
@@ -104,14 +105,18 @@ public class AdminEndpointTest {
   public void testSkipMessage() {
     // Given
     String testMessageHash = "test message hash";
+    String testOriginatingUser = "foo@bar.com";
     CachingDataStore cachingDataStore = mock(CachingDataStore.class);
     AdminEndpoint underTest = new AdminEndpoint(cachingDataStore, 500, null);
 
     // When
-    underTest.skipMessage(testMessageHash);
+    SkipMessageRequest skipMessageRequest = new SkipMessageRequest();
+    skipMessageRequest.setMessageHash(testMessageHash);
+    skipMessageRequest.setSkippingUser(testOriginatingUser);
+    underTest.skipMessage(skipMessageRequest);
 
     // Then
-    verify(cachingDataStore).skipMessage(eq(testMessageHash));
+    verify(cachingDataStore).skipMessage(eq(testMessageHash), eq(testOriginatingUser));
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ssdc/exceptionmanager/persistence/CachingDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/exceptionmanager/persistence/CachingDataStoreTest.java
@@ -181,7 +181,7 @@ public class CachingDataStoreTest {
 
     assertThat(underTest.shouldWeSkipThisMessage(exceptionReport)).isFalse();
 
-    underTest.skipMessage("test message hash");
+    underTest.skipMessage("test message hash", "foo@bar.com");
 
     assertThat(underTest.shouldWeSkipThisMessage(exceptionReport)).isTrue();
   }
@@ -471,7 +471,7 @@ public class CachingDataStoreTest {
     exceptionReportOne.setService("test service");
 
     underTest.updateStats(exceptionReportOne);
-    underTest.skipMessage("test message hash");
+    underTest.skipMessage("test message hash", "foo@bar.com");
 
     ExceptionReport exceptionReportTwo = new ExceptionReport();
     exceptionReportTwo.setMessageHash("another test message hash");


### PR DESCRIPTION
# Motivation and Context
We want an audit trail of who quarantined messages.

# What has changed
Did a best attempt at linking the user who originally requested that a message be 'skipped' to the eventual implementation of that request by the Exception Manager. User is recorded in a `skipping_user` database column in the `quarantined_message` table.

# How to test?
Create a bad message, either using the docker dev `publish_message.sh` script locally, or by publishing directly to a topic in GCP. Then, use the support tool to skip a message. Also, try skipping a message using the toolbox bad message wizard. Check the database - it should have recorded the user who skipped the message!

# Links
Trello: https://trello.com/c/JNPHZeos