### PR TITLE
Allow simultaneous builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ jdk: openjdk11
 before_install:
   - mvn fmt:check
   - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  - docker network create ssdcrmdockerdev_default
 
 install: echo "SKIPPING DEFAULT INSTALL" # Travis has a default maven install. Don't build twice!
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.8</version>
+        <version>2.9.1</version>
         <executions>
           <execution>
             <goals>

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:15432/postgres
+    url: jdbc:postgresql://localhost:15434/postgres
 
 general-config:
   number-of-retries-before-logging: 0

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -2,12 +2,10 @@ version: '2.1'
 services:
   postgres-exceptionmanager-it:
     container_name: postgres-exceptionmanager-it
-    image: postgres:13
+    image: eu.gcr.io/ssdc-rm-ci/rm/ssdc-rm-dev-common-postgres:latest
     command: ["-c", "shared_buffers=256MB", "-c", "max_connections=500"]
     ports:
       - "15434:5432"
-    environment:
-      - POSTGRES_PASSWORD=postgres
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -17,4 +17,4 @@ services:
 networks:
   default:
     external:
-      name: network_exceptionmanager-it_default
+      name: ssdcrmdockerdev_default

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '2.1'
 services:
-  postgres:
+  postgres-exceptionmanager-it:
     container_name: postgres-exceptionmanager-it
     image: postgres:13
     command: ["-c", "shared_buffers=256MB", "-c", "max_connections=500"]
     ports:
-      - "15432:5432"
+      - "15434:5432"
     environment:
       - POSTGRES_PASSWORD=postgres
     healthcheck:
@@ -13,3 +13,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+networks:
+  default:
+    external:
+      name: network_exceptionmanager-it_default


### PR DESCRIPTION
# Motivation and Context
The Docker containers needed to make the integration tests clash with each other on ports, so can't be run at the same time as other projects/repos.

# What has changed
Juggled the ports around to make them independent. Also, other fiddly stuff so that all the images/containers don't clash.

# How to test?
Try building two or more projects at the same time, and it should work with no problems.

# Links
Trello: https://trello.com/c/4FrIJ1LW