### PR TITLE
add second docker login command to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ jdk: openjdk11
 before_install:
   - mvn fmt:check
   - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  - docker login -u "${DOCKERHUB_USERNAME}" -p "${DOCKERHUB_PASSWORD}";
   - docker network create ssdcrmdockerdev_default
 
 install: echo "SKIPPING DEFAULT INSTALL" # Travis has a default maven install. Don't build twice!


### PR DESCRIPTION
# Motivation and Context
our travis builds are failing often due to dockerhub rate limiting failures, to solve this we need to log into an dockerhub enterprise account

# What has changed
- added a second docker login command line into .travis to use a enterprise dockerhub account

# How to test?
- trigger tests in travis and make sure it doesn't fail
