### PR TITLE
Java 17 and spring boot 2 6 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 language: java
-jdk: openjdk11
+jdk: openjdk17
 
 before_install:
   - mvn fmt:check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM openjdk:11-slim
+FROM openjdk:17-slim
 
-CMD ["/usr/local/openjdk-11/bin/java", "-jar", "/opt/ssdc-rm-exception-manager.jar"]
+CMD ["/usr/local/openjdk-17/bin/java", "-jar", "/opt/ssdc-rm-exception-manager.jar"]
 
 RUN apt-get update && \
 apt-get -yq install curl && \

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,11 @@
   <parent>
     <artifactId>spring-boot-starter-parent</artifactId>
     <groupId>org.springframework.boot</groupId>
-    <version>2.5.2</version>
+    <version>2.6.0</version>
   </parent>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <version>1.0-SNAPSHOT</version>
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.3</version>
+        <version>0.8.7</version>
         <executions>
           <execution>
             <goals>
@@ -132,8 +132,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.11</source>
-          <target>1.11</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
     </plugins>
@@ -159,7 +159,7 @@
       <artifactId>lombok</artifactId>
       <groupId>org.projectlombok</groupId>
       <scope>provided</scope>
-      <version>1.18.6</version>
+      <version>1.18.20</version>
     </dependency>
     <dependency>
       <artifactId>logging</artifactId>


### PR DESCRIPTION
# Motivation and Context
Java 11 is no longer the LTS (Long-Term Support) version. Java 17 is the LTS version, so we should use that.

Spring Boot 2.6.0 is the first version of Spring Boot to support Java 17, so we should use that too.

# What has changed
Upgraded to Java 17 and Spring Boot 2.6.0, plus upped any other versions required for everything to work.

Switched the Docker base image over to be JDK 17 too.

# How to test?
Zero regression.

# Links
[Trello: https://trello.com/c/kcJGECdH](https://trello.com/c/g2Igb5P1/3137-update-exception-manager-to-java-17)