### PR TITLE
Bump to Spring Boot 2.6.2 and remove Log4j version from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,11 @@
   <parent>
     <artifactId>spring-boot-starter-parent</artifactId>
     <groupId>org.springframework.boot</groupId>
-    <version>2.6.0</version>
+    <version>2.6.2</version>
   </parent>
 
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
-    <log4j2.version>2.17.0</log4j2.version>
   </properties>
 
   <version>1.0-SNAPSHOT</version>


### PR DESCRIPTION
# Motivation and Context
Tidying up after the log4j zero day.

# What has changed
Bumped Spring Boot up to 2.6.2 and removed the explicit log4j version.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/RILwmR5e