### PR TITLE
update base image to  eclipse-temurin:17-jdk-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 FROM eclipse-temurin:17-jdk-alpine
 
-CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/ssdc-rm-exception-manager.jar"]
-
+CMD ["java", "-jar", "/opt/ssdc-rm-exception-manager.jar"]
 RUN addgroup --gid 1000 exceptionmanager && \
     adduser --system --uid 1000 exceptionmanager exceptionmanager
 USER exceptionmanager
 
-ARG JAR_FILE=ssdc-rm-exception-manager*.jar
-
-COPY target/$JAR_FILE /opt/ssdc-rm-exception-manager.jar
+COPY target/ssdc-rm-exception-manager*.jar /opt/ssdc-rm-exception-manager.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM openjdk:17-slim
+FROM eclipse-temurin:17-jdk-alpine
 
-CMD ["/usr/local/openjdk-17/bin/java", "-jar", "/opt/ssdc-rm-exception-manager.jar"]
+CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/ssdc-rm-exception-manager.jar"]
 
-RUN apt-get update && \
-apt-get -yq install curl && \
-apt-get -yq clean && \
-rm -rf /var/lib/apt/lists/*
-
-RUN groupadd --gid 999 exceptionmanager && \
-    useradd --create-home --system --uid 999 --gid exceptionmanager exceptionmanager
+RUN addgroup --gid 1000 exceptionmanager && \
+    adduser --system --uid 1000 exceptionmanager exceptionmanager
 USER exceptionmanager
 
 ARG JAR_FILE=ssdc-rm-exception-manager*.jar
+
 COPY target/$JAR_FILE /opt/ssdc-rm-exception-manager.jar


### PR DESCRIPTION
# Motivation and Context
OpenJDK support not great, use this eclipse alpine instead

# What has changed
Base image and healthchecks, user etc

# How to test?
Should all work with ATs etc with zero regression

# Links
https://trello.com/c/EK2yClBJ/40-migrate-java-base-docker-image-5