### PR TITLE
Added bad message count endpoint

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpoint.java
@@ -45,6 +45,11 @@ public class AdminEndpoint {
     return ResponseEntity.status(HttpStatus.OK).body(getSeenMessageHashes(minimumSeenCount));
   }
 
+  @GetMapping(path = "/badmessages/count")
+  public ResponseEntity<Integer> getBadMessagesCount() {
+    return ResponseEntity.status(HttpStatus.OK).body(cachingDataStore.getSeenMessageCount());
+  }
+
   @GetMapping(path = "/badmessages/summary")
   public ResponseEntity<List<BadMessageSummary>> getBadMessagesSummary(
       @RequestParam(value = "minimumSeenCount", required = false, defaultValue = "-1")

--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/persistence/CachingDataStore.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/persistence/CachingDataStore.java
@@ -138,6 +138,10 @@ public class CachingDataStore {
     return messageExceptionReports.keySet();
   }
 
+  public int getSeenMessageCount() {
+    return messageExceptionReports.keySet().size();
+  }
+
   public Set<String> getSeenMessageHashes(int minimumSeenCount) {
     Set<String> result = new HashSet<>();
 

--- a/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpointTest.java
@@ -45,6 +45,21 @@ public class AdminEndpointTest {
   }
 
   @Test
+  public void testGetBadMessageCount() {
+    // Given
+    CachingDataStore cachingDataStore = mock(CachingDataStore.class);
+    when(cachingDataStore.getSeenMessageCount()).thenReturn(10);
+    AdminEndpoint underTest = new AdminEndpoint(cachingDataStore, 500);
+
+    // When
+    ResponseEntity<Integer> actualResponse = underTest.getBadMessagesCount();
+
+    // Then
+    assertThat(actualResponse.getBody()).isEqualTo(10);
+    verify(cachingDataStore).getSeenMessageCount();
+  }
+
+  @Test
   public void getBadMessagesSummary() {
     // Given
     CachingDataStore cachingDataStore = mock(CachingDataStore.class);


### PR DESCRIPTION
# Motivation and Context
The support tool exception manager page struggles to load too many messages and becomes unusable with high amounts

# What has changed
Added new endpoint to provide the count of bad messages

# How to test?
Create bad messages and call count endpoint 
