### PR TITLE
1234 dependabot patch label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "daily"
     labels:
       - "patch"
+      - "dependencies"


### PR DESCRIPTION
# Motivation and Context
All dependabot PRs are currently blocked because they don’t include our mandatory versioning labels, which obscures which ones pass the tests without a deeper dive.

# What has changed
Added labels to the dependabot config file

# How to test?
Check the labels

# Links
https://trello.com/c/ZPLTDik6

# Screenshots (if appropriate):