### PR TITLE
1247 custom docker compose script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build: install docker-build
 build-no-test: install-no-test docker-build
 
 install-no-test:
-	mvn clean install -Dmaven.test.skip=true -DdockerCompose.skip=true
+	mvn clean install -Dmaven.test.skip=true -Dexec.skip=true
 format:
 	mvn fmt:format
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,30 +60,30 @@
         <groupId>org.apache.maven.plugins</groupId>
       </plugin>
       <plugin>
-        <groupId>com.dkanejs.maven.plugins</groupId>
-        <artifactId>docker-compose-maven-plugin</artifactId>
-        <version>2.4.0</version>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
-            <id>up</id>
+            <id>Docker Compose Up</id>
             <phase>pre-integration-test</phase>
             <goals>
-              <goal>up</goal>
+              <goal>exec</goal>
             </goals>
             <configuration>
-              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
-              <detachedMode>true</detachedMode>
+              <executable>docker</executable>
+              <commandlineArgs>compose -f src/test/resources/docker-compose.yml up -d</commandlineArgs>
             </configuration>
           </execution>
           <execution>
-            <id>down</id>
+            <id>Docker Compose Down</id>
             <phase>post-integration-test</phase>
             <goals>
-              <goal>down</goal>
+              <goal>exec</goal>
             </goals>
             <configuration>
-              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
-              <removeVolumes>true</removeVolumes>
+              <executable>docker</executable>
+              <commandlineArgs>compose -f src/test/resources/docker-compose.yml down -v</commandlineArgs>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
# Motivation and Context
The maven plugin we use for docker compose on our java projects is no longer compatible and we concluded the best solution was to create a custom script to replace this.

# What has changed
Changed the original plugin to a custom one
Amended make command that skips docker compose 

# How to test?
Check it works locally on your machine

# Links
(https://trello.com/c/yOWPLr4O)

# Screenshots (if appropriate):