### PR TITLE
1288 upgrade spring boot version in java repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>spring-boot-starter-parent</artifactId>
     <groupId>org.springframework.boot</groupId>
-    <version>2.6.6</version>
+    <version>3.2.2</version>
   </parent>
 
   <properties>
@@ -189,9 +189,9 @@
       <version>1.2.5</version>
     </dependency>
     <dependency>
-      <groupId>com.vladmihalcea</groupId>
-      <artifactId>hibernate-types-55</artifactId>
-      <version>2.21.1</version>
+      <groupId>io.hypersistence</groupId>
+      <artifactId>hypersistence-utils-hibernate-63</artifactId>
+      <version>3.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/config/AppConfig.java
@@ -1,8 +1,8 @@
 package uk.gov.ons.ssdc.exceptionmanager.config;
 
 import com.godaddy.logging.LoggingConfigs;
+import jakarta.annotation.PostConstruct;
 import java.util.TimeZone;
-import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;

--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpoint.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.exceptionmanager.endpoint;
 
+import jakarta.transaction.Transactional;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashSet;
@@ -9,7 +10,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/ReportingEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/ReportingEndpoint.java
@@ -1,8 +1,8 @@
 package uk.gov.ons.ssdc.exceptionmanager.endpoint;
 
+import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.UUID;
-import javax.transaction.Transactional;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/entity/AutoQuarantineRule.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/entity/AutoQuarantineRule.java
@@ -1,10 +1,10 @@
 package uk.gov.ons.ssdc.exceptionmanager.model.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import java.time.OffsetDateTime;
 import java.util.UUID;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
 import lombok.Data;
 
 @Data

--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/entity/QuarantinedMessage.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/entity/QuarantinedMessage.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.exceptionmanager.model.entity;
 
+import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -10,6 +11,7 @@ import java.util.UUID;
 import lombok.Data;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Type;
 import org.hibernate.type.SqlTypes;
 
 @Data
@@ -38,11 +40,11 @@ public class QuarantinedMessage {
 
   @Column private String skippingUser;
 
-  @JdbcTypeCode(SqlTypes.JSON)
+  @Type(JsonBinaryType.class)
   @Column(columnDefinition = "jsonb")
   private Map<String, String> headers;
 
-  @JdbcTypeCode(SqlTypes.JSON)
+  @Type(JsonBinaryType.class)
   @Column(columnDefinition = "jsonb")
   private String errorReports;
 }

--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/entity/QuarantinedMessage.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/entity/QuarantinedMessage.java
@@ -1,23 +1,19 @@
 package uk.gov.ons.ssdc.exceptionmanager.model.entity;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
 import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.UUID;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Lob;
 import lombok.Data;
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
-import org.hibernate.annotations.TypeDefs;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Data
 @Entity
-@TypeDefs({@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)})
 public class QuarantinedMessage {
   @Id private UUID id;
 
@@ -28,7 +24,7 @@ public class QuarantinedMessage {
   @Column private String messageHash;
 
   @Lob
-  @Type(type = "org.hibernate.type.BinaryType")
+  @JdbcTypeCode(SqlTypes.VARBINARY)
   @Column
   private byte[] messagePayload;
 
@@ -42,11 +38,11 @@ public class QuarantinedMessage {
 
   @Column private String skippingUser;
 
-  @Type(type = "jsonb")
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(columnDefinition = "jsonb")
-  private Map<String, JsonNode> headers;
+  private Map<String, String> headers;
 
-  @Type(type = "jsonb")
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(columnDefinition = "jsonb")
   private String errorReports;
 }

--- a/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/entity/QuarantinedMessage.java
+++ b/src/main/java/uk/gov/ons/ssdc/exceptionmanager/model/entity/QuarantinedMessage.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.exceptionmanager.model.entity;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,7 +43,7 @@ public class QuarantinedMessage {
 
   @Type(JsonBinaryType.class)
   @Column(columnDefinition = "jsonb")
-  private Map<String, String> headers;
+  private Map<String, JsonNode> headers;
 
   @Type(JsonBinaryType.class)
   @Column(columnDefinition = "jsonb")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
       maximumPoolSize: 50
 
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
     properties:

--- a/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/AdminEndpointIT.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/ReportingEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/ReportingEndpointIT.java
@@ -6,6 +6,7 @@ import static org.springframework.http.HttpStatus.OK;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
@@ -214,7 +215,7 @@ public class ReportingEndpointIT {
     assertThat(quarantinedMessage.getContentType()).isEqualTo(skippedMessage.getContentType());
     assertThat(quarantinedMessage.getHeaders().size())
         .isEqualTo(skippedMessage.getHeaders().size());
-    assertThat(quarantinedMessage.getHeaders().get("foo")).isEqualTo("bar");
+    assertThat(quarantinedMessage.getHeaders().get("foo")).isEqualTo(TextNode.valueOf("bar"));
     assertThat(quarantinedMessage.getMessagePayload())
         .isEqualTo(skippedMessage.getMessagePayload());
     assertThat(quarantinedMessage.getRoutingKey()).isEqualTo(skippedMessage.getRoutingKey());

--- a/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/ReportingEndpointIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/exceptionmanager/endpoint/ReportingEndpointIT.java
@@ -6,7 +6,6 @@ import static org.springframework.http.HttpStatus.OK;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
@@ -21,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.ons.ssdc.exceptionmanager.model.dto.AutoQuarantineRule;
@@ -215,7 +214,7 @@ public class ReportingEndpointIT {
     assertThat(quarantinedMessage.getContentType()).isEqualTo(skippedMessage.getContentType());
     assertThat(quarantinedMessage.getHeaders().size())
         .isEqualTo(skippedMessage.getHeaders().size());
-    assertThat(quarantinedMessage.getHeaders().get("foo")).isEqualTo(new TextNode("bar"));
+    assertThat(quarantinedMessage.getHeaders().get("foo")).isEqualTo("bar");
     assertThat(quarantinedMessage.getMessagePayload())
         .isEqualTo(skippedMessage.getMessagePayload());
     assertThat(quarantinedMessage.getRoutingKey()).isEqualTo(skippedMessage.getRoutingKey());


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Spring Boot 3 has been out for a while and Dependabot wants us to upgrade to it. There's quite a few changes which you look up for yourselves. I listed main changes to each repo on the ticket.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Move to Jakarta resources instead of Javax
- updated postgresdialect to `PostgreSQLDialect`
- Updated ddl settings to match with what Hibernate 6 expects
- localwebserver comes from the test location now instead of server
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run `make build` this branch
- Run `make build` on the  UAC QID branch
- This branch needs to be built BEFORE the ddl is built. 
- Once this branch has been built, go to the ddl repo and run `UAC_QID_SERVICE_BRANCH=1288-upgrade-spring-boot-version-in-java-repos EXCEPTION_MANAGER_BRANCH=1288-upgrade-spring-boot-version-in-java-repos make dev-build
`. This should build the expected ddl changes for you.
- run `make build` on the rest of the java services
- Run the ATs and make sure everything works as expected.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/Oo7EZ4q4/)
# Screenshots (if appropriate):