### PR TITLE
SDCSRM-1273 Java Jackson logging error

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -58,10 +58,8 @@
                     <fieldName>data</fieldName>
                     <providers>
                         <arguments>
-                            <includeNonStructuredArguments>true
+                            <includeNonStructuredArguments>false
                             </includeNonStructuredArguments>
-                            <nonStructuredArgumentsFieldPrefix>prefix
-                            </nonStructuredArgumentsFieldPrefix>
                         </arguments>
                         <keyValuePairs>
                         </keyValuePairs>


### PR DESCRIPTION
# Motivation and Context
When Java apps startup we get an error in the logger:
```
Error encountered while encoding log event. Event: [INFO] HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@4a14f7d7 com.fasterxml.jackson.databind.JsonMappingException: Document nesting depth (1001) exceeds the maximum allowed (1000, from `StreamWriteConstraints.getMaxNestingDepth()
```

From having a dig around we've started seeing the error since we upgraded to Spring Boot 3.5 from 3.2, as part of the update our jackson.fasterxml was updated to v2.19.2 (I can't confirm the exact version we used prior but it would be <=2.15.4).
In 2.15.0  a configurable limit for how deep Jackson will traverse an input was added (by default it's set to 1000). This was to address a security vulnerability ([read more here](https://www.ibm.com/support/pages/security-bulletin-jackson-core-prior-2150-due-unbounded-nesting-json-input)).

The reason we hit this limits is we allow non-structured arguments when encoding logs, which can cause an infinite cyclic reference - which is what happened with the HikariPool log. 
In our case HikariPool would create a log but jackson would end up in a loop trying to encode:
`org.postgresql.jdbc.PgConnection["metaData"]->org.postgresql.jdbc.PgDatabaseMetaData["connection"]->org.postgresql.jdbc.PgConnection["metaData"]->...` until it hit the max nesting depth.

# What has changed
- Disabled non structured arguments
In the example above now the log looks like and won't include the recursive augment:
```
HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@76f9e000
```

_(This may remove some helpful arguments in logs - I haven't seen this when testing this fix, however from my understanding you should try and probably structure your arguments in logs - if this becomes an issue we can always enable it for dev projects or try and update our logging to probably structure the error log)_

# How to test?
- Build it locally and deploy to a GCP project, check the logs and make sure there's no more errors.

# Links
[Jira SDCSRM-1273](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1273)

# Screenshots (if appropriate):
