### PR TITLE
Update spring boot starter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>spring-boot-starter-parent</artifactId>
     <groupId>org.springframework.boot</groupId>
-    <version>3.5.7</version>
+    <version>3.5.12</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
# Motivation and Context
We're affected by CVE-2026-22732 

# What has changed
Bumped spring boot parent to 3.5.12

# How to test?
Run it in a dev project and check ATs still work

# Links
[SDCSRM-1468](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1468)
