### PR TITLE
SDCSRM-1527 Bump Github actions for Node 24

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -26,7 +26,7 @@ jobs:
       # And acquire a token for authenticating with the docker registry
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           token_format: 'access_token'
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
@@ -34,21 +34,21 @@ jobs:
 
       # Authenticating with Dockerhub ensures image pulls are authenticated, so not as severely rate limited
       - name: Log in to Dockerhub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Also log docker in to GCP, to allow image pulls from our private registries
       - name: Log in to Google Docker Artifact Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: europe-west2-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set Up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Google auth allows maven to pull artifacts from our registry
       # And acquire a token for authenticating with the docker registry

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Motivation and Context
GitHub Actions are removing support for node 20, so we need to bump our actions so they are compatible with Node 24


# What has changed
Bumped github actions

# How to test?
Check the actions run on this PR and there are no warnings

# Links
[SDCSRM-1527](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1527)

# Screenshots (if appropriate):