### PR TITLE
SDCSRM-1591: Bump Spring Boot to 3.5.16 (fixes jackson-databind + logback)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>spring-boot-starter-parent</artifactId>
     <groupId>org.springframework.boot</groupId>
-    <version>3.5.13</version>
+    <version>3.5.16</version>
   </parent>
 
   <properties>
@@ -225,7 +225,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.25</version>
     </dependency>
     <dependency>
       <groupId>net.logstash.logback</groupId>
@@ -235,7 +234,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.5.25</version>
     </dependency>
     <dependency>
       <groupId>io.hypersistence</groupId>


### PR DESCRIPTION
# Motivation and Context
Security Command Center flagged `jackson-databind` (CVE-2026-54512 / CVE-2026-54513) in this service. `jackson-databind` is managed transitively via the Spring Boot BOM, so bumping Spring Boot to 3.5.16 pulls the fixed `jackson-databind` 2.21.4.

This also removes the hard-pinned logback versions. `logback-classic` and `logback-core` were both explicitly pinned to 1.5.25, which let Dependabot bump `logback-core` alone (to 1.5.33) and break the build — the two must be the same version. Letting the Spring Boot BOM manage logback resolves both to a matched pair (1.5.34) and prevents the split-pin problem, superseding the failing Dependabot `logback-core` PR (#89).

# What has changed
* Bumped `spring-boot-starter-parent` to **3.5.16** (→ `jackson-databind` 2.21.4).
* Removed the explicit `<version>` from `ch.qos.logback:logback-classic` and `ch.qos.logback:logback-core` so they are BOM-managed (matched pair, now **1.5.34**). `logstash-logback-encoder` unchanged.

# How to test?
`mvn test` passes (34 passed). Confirmed logback resolves to a matched 1.5.34 pair via `mvn dependency:tree -Dincludes=ch.qos.logback`.

# Links
* [SDCSRM-1591](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1591)
* Supersedes Dependabot PR #89 in this repo.


[SDCSRM-1591]: https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ